### PR TITLE
Avoid reading constant pool everywhere

### DIFF
--- a/common/include/classloader/classfile.h
+++ b/common/include/classloader/classfile.h
@@ -16,13 +16,16 @@ struct ClassFile {
 	uint16_t major;
 	ConstantPool* constantPool;
 	uint16_t accessFlags;
-	uint16_t thisClass;
-	uint16_t superClass;
+	uint16_t thisClassIndex;
+	uint16_t superClassIndex;
 	InterfacePool* interfacePool;
     FieldPool* fieldPool;
     MethodPool* methodPool;
     AttributePool* attributePool;
 
+	Class* thisClass;
+	Class* superClass;
+	UTF8* name;
 	struct StaticFields* staticFields;
 };
 

--- a/common/include/classloader/constantparser.h
+++ b/common/include/classloader/constantparser.h
@@ -26,19 +26,24 @@ typedef struct {
 } UTF8;
 
 typedef struct {
-	uint16_t classIndex;
-	uint16_t nameAndTypeIndex;
-} MethodRef;
-
-typedef struct {
 	uint16_t nameIndex;
-    ClassFile* classFile;
+	UTF8* name;
+	ClassFile* classFile;
 } Class;
 
 typedef struct {
 	uint16_t nameIndex;
 	uint16_t descriptorIndex;
-} NameAndTypeIndex;
+	UTF8* name;
+	UTF8* descriptor;
+} NameAndType;
+
+typedef struct {
+	uint16_t classIndex;
+	uint16_t nameAndTypeIndex;
+	NameAndType* nameAndType;
+	Class* class;
+} MethodRef;
 
 typedef struct {
 	int32_t value;
@@ -58,6 +63,7 @@ typedef struct {
 
 typedef struct {
 	uint16_t index;
+	UTF8* string;
 } String;
 
 typedef struct {
@@ -78,7 +84,7 @@ typedef union {
 	UTF8* utf8;
 	MethodRef* methodRef;
 	Class* class;
-	NameAndTypeIndex* nameAndTypeIndex;
+	NameAndType* nameAndType;
 	Integer* integer;
 	Float* f;
 	Long* l;

--- a/common/include/classloader/fieldpoolloader.h
+++ b/common/include/classloader/fieldpoolloader.h
@@ -21,6 +21,8 @@ typedef struct {
 	uint16_t accessFlags;
 	uint16_t nameIndex;
 	uint16_t descriptorIndex;
+	UTF8* name;
+	UTF8* descriptor;
     AttributePool* attributePool;
 } FieldPoolItem;
 

--- a/common/include/classloader/methodparser.h
+++ b/common/include/classloader/methodparser.h
@@ -6,9 +6,9 @@
 
 typedef struct {
     uint16_t accessFlags;
-    uint16_t nameIndex;
-    uint16_t descriptorIndex;
     uint16_t argumentCount;
+    UTF8* name;
+    UTF8* descriptor;
     AttributePool* attributePool;
 } MethodInfo;
 

--- a/common/include/utils/constantpoolhelper.h
+++ b/common/include/utils/constantpoolhelper.h
@@ -17,7 +17,7 @@ UTF8* parseClassToUTF8ByIndex(int index, const ConstantPool* constantPool);
 
 char* parseClassByIndex(int index, const ConstantPool* constantPool);
 
-char* parseNameAndType(NameAndTypeIndex* nameAndTypeIndex, const ConstantPool* constantPool);
+char* parseNameAndType(NameAndType* nameAndTypeIndex, const ConstantPool* constantPool);
 
 char* parseNameAndTypeByIndex(int index, const ConstantPool* constantPool);
 

--- a/common/src/classloader/attributehelper.c
+++ b/common/src/classloader/attributehelper.c
@@ -134,10 +134,9 @@ void printFileAttributes(ConstantPool* constantPool, AttributePool* attributePoo
                     MethodHandle * methodHandle = constantPool->pool[method->methodRef-1]->constant->methodHandle;
                     MethodRef* methodRef = constantPool->pool[methodHandle->referenceIndex-1]->constant->methodRef;
                     Class* class = constantPool->pool[methodRef->classIndex-1]->constant->class;
-                    NameAndTypeIndex* nameAndTypeIndex = constantPool->pool[methodRef->nameAndTypeIndex - 1]->constant->nameAndTypeIndex;
                     UTF8* className = constantPool->pool[class->nameIndex - 1]->constant->utf8;
-                    UTF8* methodName = constantPool->pool[nameAndTypeIndex->nameIndex - 1]->constant->utf8;
-                    UTF8* typeName = constantPool->pool[nameAndTypeIndex->descriptorIndex-1]->constant->utf8;
+                    UTF8* methodName = methodRef->nameAndType->name;
+                    UTF8* typeName = methodRef->nameAndType->descriptor;
                     printf("\t%d: #%d %s.%s:%s\n\t\tMethod Arguments:\n", j, method->methodRef, utf82cstring(className),
                            utf82cstring(methodName), utf82cstring(typeName));
 

--- a/common/src/classloader/classfileloader.c
+++ b/common/src/classloader/classfileloader.c
@@ -36,26 +36,26 @@ ClassFile* loadClassFile(const char* classFilePath) {
 }
 
 CStringArray* getDependencyClasses(ClassFile* classFile) {
-    int thisIndex = classFile->thisClass;
     ConstantPool* constantPool = classFile->constantPool;
 
     //number of classes referenced in the constant pool of the given classFile
     int numClasses = 0;
     for(int i = 0; i < constantPool->size; i++) {
         if(!constantPool->pool[i]) continue;
-        if(i == thisIndex-1) continue; //the 'this' class name
         int tag = constantPool->pool[i]->tag;
         if(tag == CONSTANT_CLASS) numClasses++;
     }
+    numClasses--; // thisClass shouldn't count
 
     CStringArray* result = allocCStringArray(numClasses);
     int numResultsWritten = 0;
     for(int i = 0; i < constantPool->size; i++) {
         if(!constantPool->pool[i]) continue; //spot is empty
-        if(i == thisIndex-1) continue; //the 'this' class name
         if(constantPool->pool[i]->tag == CONSTANT_CLASS) {
             //We need to add 1 to the index because class files are 1-indexed
             UTF8* nameUtf8 = parseClassToUTF8ByIndex(i+1, constantPool);
+
+            if (nameUtf8 == classFile->name) continue; // skip this class
 
             CStringArray* subList = malloc(sizeof(CStringArray));
             subList->values = result->values;

--- a/common/src/classloader/classfileparser.c
+++ b/common/src/classloader/classfileparser.c
@@ -80,18 +80,44 @@ void getConstantString(char * const buffer, ConstantPoolInfo* item) {
             free(cstring);
             break;
         }
-		case CONSTANT_NAME_AND_TYPE:
-			sprintf(buffer, "#%d:#%d", constant->nameAndType->nameIndex, constant->nameAndType->descriptorIndex);
+		case CONSTANT_NAME_AND_TYPE: {
+			char* nameString = utf82cstring(constant->nameAndType->name);
+			char* descriptorString = utf82cstring(constant->nameAndType->descriptor);
+			sprintf(buffer, "#%d:#%d (%s %s)", constant->nameAndType->nameIndex, constant->nameAndType->descriptorIndex, descriptorString, nameString);
+			free(nameString);
+			free(descriptorString);
 			break;
-		case CONSTANT_CLASS:
-			sprintf(buffer, "#%d", constant->class->nameIndex);
+		}
+		case CONSTANT_CLASS: {
+			char* classString = utf82cstring(constant->class->name);
+			sprintf(buffer, "#%d (%s)", constant->class->nameIndex, classString);
+			free(classString);
 			break;
-		case CONSTANT_METHOD_REF:
-		case CONSTANT_FIELD_REF:
-			sprintf(buffer, "#%d.#%d", constant->methodRef->classIndex, constant->methodRef->nameAndTypeIndex);
+		}
+		case CONSTANT_FIELD_REF: {
+			char* classString = utf82cstring(constant->methodRef->class->name);
+			char* nameString = utf82cstring(constant->methodRef->nameAndType->name);
+			char* descriptor = utf82cstring(constant->methodRef->nameAndType->descriptor);
+			sprintf(buffer, "#%d.#%d (%s %s.%s)", constant->methodRef->classIndex, constant->methodRef->nameAndTypeIndex, descriptor, classString, nameString);
+			free(nameString);
+			free(classString);
+			free(descriptor);
 			break;
+		}
+		case CONSTANT_METHOD_REF: {
+			char* classString = utf82cstring(constant->methodRef->class->name);
+			char* nameString = utf82cstring(constant->methodRef->nameAndType->name);
+			char* descriptorString = utf82cstring(constant->methodRef->nameAndType->descriptor);
+			sprintf(buffer, "#%d.#%d (%s.%s %s)", constant->methodRef->classIndex, constant->methodRef->nameAndTypeIndex, classString, nameString, descriptorString);
+			free(nameString);
+			free(classString);
+			free(descriptorString);
+			break;
+		}
 		case CONSTANT_STRING:
+			char* text = utf82cstring(constant->string->string);
 			sprintf(buffer, "#%d", constant->string->index);
+			free(text);
 			break;
         case CONSTANT_INVOKE_DYNAMIC:
             sprintf(buffer, "#%d:#%d", constant->invokeDynamic->bootstrapMethodAttrIndex, constant->invokeDynamic->nameAndTypeIndex);
@@ -167,7 +193,7 @@ void printConstantPool(const ConstantPool *constantPool) {
     for(int i = 0; i < constantPool->size; i++) {
         ConstantPoolInfo* item = constantPool->pool[i];
         if(item) {
-            char* constantString = malloc(60*sizeof(char));
+            char* constantString = malloc(150*sizeof(char));
             getConstantString(constantString, item);
             printf("%5d %-20s %s\n", i+1, getTagName(item), constantString);
             free(constantString);

--- a/common/src/classloader/classfileparser.c
+++ b/common/src/classloader/classfileparser.c
@@ -160,10 +160,15 @@ void printFieldPool(const ConstantPool *constantPool, const FieldPool *fieldPool
     printf("\nField Pool:\n");
     for(int i = 0; i < fieldPool->size; i++) {
         FieldPoolItem* field = fieldPool->pool[i];
+    	char* fieldName = utf82cstring(field->name);
+    	char* descriptor = utf82cstring(field->descriptor);
         printf("\nField #%d:\n", i+1);
-        printf("%s\n", utf82cstring(field->name));
+        printf("%s\n", fieldName);
         printf("\tAccess Flags: %x\n", field->accessFlags);
-        printf("\tdescriptor: %s\n", utf82cstring(field->descriptor));
+        printf("\tdescriptor: %s\n", descriptor);
+
+    	free(fieldName);
+    	free(descriptor);
 
         for(int j = 0; j < field->attributePool->size; j++) {
             Attribute* attribute = field->attributePool->attributes[j];

--- a/common/src/classloader/classloader.c
+++ b/common/src/classloader/classloader.c
@@ -24,8 +24,7 @@ ClassLoader* createClassLoader(const char* classPath, const char* javaClassPath,
 int indexOfClassFile(ClassLoader* classLoader, const char* classFileName) {
     for(int i = 0; i < classLoader->classPool->size; i++) {
         ClassFile* classFile = classLoader->classPool->classFiles[i];
-        int index = classFile->thisClass;
-        UTF8* utf8 = parseClassToUTF8ByIndex(index, classFile->constantPool);
+        UTF8* utf8 = classFile->name;
         if(isEqual(utf8, classFileName)) return i;
     }
     return -1;

--- a/common/src/classloader/fieldpoolloader.c
+++ b/common/src/classloader/fieldpoolloader.c
@@ -14,9 +14,11 @@ FieldPool* parseFieldPool(ConstantPool* constantPool, const uint8_t** content) {
     for(int i = 0; i < fieldCount; i++) {
         FieldPoolItem* fieldPoolItem = malloc(sizeof(FieldPoolItem));
         fieldPoolItem->accessFlags = readuInt16(content);
-        fieldPoolItem->nameIndex = readuInt16(content);
-        fieldPoolItem->descriptorIndex = readuInt16(content);
+        const uint16_t nameIndex = readuInt16(content);
+        const uint16_t descriptorIndex = readuInt16(content);
 
+        fieldPoolItem->name = constantPool->pool[nameIndex-1]->constant->utf8;
+        fieldPoolItem->descriptor = constantPool->pool[descriptorIndex-1]->constant->utf8;
         AttributePool* attributePool = parseAttributes(constantPool, content);
 
         fieldPoolItem->attributePool = attributePool;

--- a/common/src/classloader/methodparser.c
+++ b/common/src/classloader/methodparser.c
@@ -78,7 +78,9 @@ MethodPool* parseMethodPool(ConstantPool* constantPool, const uint8_t** content)
         methodInfo->attributePool = parseAttributes(constantPool, content);
         methodPool->pool[i] = methodInfo;
 
-        methodInfo->argumentCount = getArgCount(utf82cstring(methodInfo->descriptor));
+        char* descriptor = utf82cstring(methodInfo->descriptor);
+        methodInfo->argumentCount = getArgCount(descriptor);
+        free(descriptor);
     }
     return methodPool;
 }

--- a/common/src/classloader/methodparser.c
+++ b/common/src/classloader/methodparser.c
@@ -69,14 +69,16 @@ MethodPool* parseMethodPool(ConstantPool* constantPool, const uint8_t** content)
         MethodInfo* methodInfo = malloc(sizeof(MethodInfo));
 
         methodInfo->accessFlags = readuInt16(content);
-        methodInfo->nameIndex = readuInt16(content);
-        methodInfo->descriptorIndex = readuInt16(content);
+        const uint16_t nameIndex = readuInt16(content);
+        const uint16_t descriptorIndex = readuInt16(content);
+
+        methodInfo->name = constantPool->pool[nameIndex-1]->constant->utf8;
+        methodInfo->descriptor = constantPool->pool[descriptorIndex-1]->constant->utf8;
 
         methodInfo->attributePool = parseAttributes(constantPool, content);
         methodPool->pool[i] = methodInfo;
 
-        UTF8* descriptor = constantPool->pool[methodInfo->descriptorIndex-1]->constant->utf8;
-        methodInfo->argumentCount = getArgCount(utf82cstring(descriptor));
+        methodInfo->argumentCount = getArgCount(utf82cstring(methodInfo->descriptor));
     }
     return methodPool;
 }

--- a/common/src/memory/objheader.c
+++ b/common/src/memory/objheader.c
@@ -77,7 +77,7 @@ int32_t getFieldValue32(ObjHeader* obj, char* field) {
 int getSizeFromDescriptor(char* descriptor) {
     if(strcmp(descriptor, "B") == 0 || strcmp(descriptor, "Z") == 0) return 1;
     if(strcmp(descriptor, "C") == 0 || strcmp(descriptor, "S") == 0) return 2;
-    if(strcmp(descriptor, "I") == 0 || strcmp(descriptor, "F") == 0) return 4;
+    if(strcmp(descriptor, "I") == 0 || strcmp(descriptor, "F") == 0 || descriptor[0] == '[') return 4;
     if(strcmp(descriptor, "J") == 0 || strcmp(descriptor, "D") == 0) return 8;
     return 4;
 }

--- a/common/src/memory/static.c
+++ b/common/src/memory/static.c
@@ -21,11 +21,7 @@ void initializeStaticFields(ClassFile* classFile) {
             continue;
         }
 
-        const int nameIndex = classFile->fieldPool->pool[i]->nameIndex;
-        const int descriptorIndex = classFile->fieldPool->pool[i]->descriptorIndex;
-        UTF8* nameUtf = classFile->constantPool->pool[nameIndex-1]->constant->utf8;
-        UTF8* descriptorUtf = classFile->constantPool->pool[descriptorIndex-1]->constant->utf8;
-        char* descriptor = utf82cstring(descriptorUtf);
+        UTF8* nameUtf = classFile->fieldPool->pool[i]->name;
         StaticField field;
 
         field.value = 0;

--- a/common/src/synthetic/class_creator.c
+++ b/common/src/synthetic/class_creator.c
@@ -50,7 +50,7 @@ ClassFile* createClassFile(const ClassCreationContext* context) {
     int poolIndex = 0;
     Class* clazz = malloc(sizeof(Class));
     addClassToConstantPool(classFile->constantPool, &poolIndex, clazz);
-    classFile->thisClass = poolIndex;
+    classFile->thisClassIndex = poolIndex;
     clazz->classFile = classFile;
 
     addStringToConstantPool(classFile->constantPool, &poolIndex, context->name);
@@ -87,13 +87,13 @@ ClassFile* createClassFile(const ClassCreationContext* context) {
     classFile->fieldPool->pool = malloc(0);
 
     if (context->superclass != nullptr) {
-        const Class* superclass = context->superclass->constantPool->pool[context->superclass->thisClass-1]->constant->class;
+        const Class* superclass = context->superclass->constantPool->pool[context->superclass->thisClassIndex-1]->constant->class;
         UTF8* superclassNameUtf8 = context->superclass->constantPool->pool[superclass->nameIndex-1]->constant->utf8;
 
         char* superclassName = utf82cstring(superclassNameUtf8);
         addStringToConstantPool(classFile->constantPool, &poolIndex, superclassName);
         free(superclassName);
-        classFile->superClass = poolIndex;
+        classFile->superClassIndex = poolIndex;
     }
 
     return classFile;

--- a/common/src/synthetic/class_creator.c
+++ b/common/src/synthetic/class_creator.c
@@ -5,7 +5,7 @@
 
 #include "classloader/utf8utils.h"
 
-void addStringToConstantPool(ConstantPool* pool, int* index, const char* text) {
+UTF8* addStringToConstantPool(ConstantPool* pool, int* index, const char* text) {
     UTF8* utf = malloc(sizeof(UTF8));
     char* copy = malloc(strlen(text) + 1);
     strcpy(copy, text);
@@ -15,6 +15,8 @@ void addStringToConstantPool(ConstantPool* pool, int* index, const char* text) {
     pool->pool[*index]->tag = CONSTANT_UTF8;
     pool->pool[*index]->constant = constant;
     *index = *index + 1;
+
+    return utf;
 }
 
 void addClassToConstantPool(ConstantPool* pool, int* index, Class* clazz) {
@@ -65,10 +67,8 @@ ClassFile* createClassFile(const ClassCreationContext* context) {
         MethodInfo* info = malloc(sizeof(MethodInfo));
         classFile->methodPool->pool[i] = info;
 
-        addStringToConstantPool(classFile->constantPool, &poolIndex, method->name);
-        info->nameIndex = poolIndex;
-        addStringToConstantPool(classFile->constantPool, &poolIndex, method->descriptor);
-        info->descriptorIndex = poolIndex;
+        info->name = addStringToConstantPool(classFile->constantPool, &poolIndex, method->name);
+        info->descriptor = addStringToConstantPool(classFile->constantPool, &poolIndex, method->descriptor);
 
         info->accessFlags = METHOD_NATIVE | METHOD_SYNTHETIC;
         info->argumentCount = method->numArgs;

--- a/common/src/utils/constantpoolhelper.c
+++ b/common/src/utils/constantpoolhelper.c
@@ -24,20 +24,16 @@ char* parseClass(Class* class, const ConstantPool* constantPool) {
     return parseUTF8ByIndex(nameIndex, constantPool);
 }
 
-UTF8* parseClassToUTF8(Class* class, const ConstantPool* constantPool) {
-    return constantPool->pool[class->nameIndex-1]->constant->utf8;
-}
-
 UTF8* parseClassToUTF8ByIndex(int index, const ConstantPool* constantPool) {
     Class* class = constantPool->pool[index-1]->constant->class;
-    return parseClassToUTF8(class, constantPool);
+    return class->name;
 }
 
 char* parseClassByIndex(int index, const ConstantPool* constantPool) {
     return parseClass(constantPool->pool[index-1]->constant->class, constantPool);
 }
 
-char* parseNameAndType(NameAndTypeIndex* nameAndTypeIndex, const ConstantPool* constantPool) {
+char* parseNameAndType(NameAndType* nameAndTypeIndex, const ConstantPool* constantPool) {
     char* nameString = parseUTF8ByIndex(nameAndTypeIndex->nameIndex, constantPool);
     char* typeString = parseUTF8ByIndex(nameAndTypeIndex->descriptorIndex, constantPool);
     char* result = malloc(strlen(nameString) + 1 + strlen(typeString) + 1);
@@ -52,7 +48,7 @@ char* parseNameAndType(NameAndTypeIndex* nameAndTypeIndex, const ConstantPool* c
 }
 
 char* parseNameAndTypeByIndex(int index, const ConstantPool* constantPool) {
-    return parseNameAndType(constantPool->pool[index-1]->constant->nameAndTypeIndex, constantPool);
+    return parseNameAndType(constantPool->pool[index-1]->constant->nameAndType, constantPool);
 }
 
 char* parseMethodRef(MethodRef* methodRef, const ConstantPool* constantPool) {

--- a/javarunner/src/execution_engine/executor.c
+++ b/javarunner/src/execution_engine/executor.c
@@ -412,8 +412,8 @@ void executeProgram(Executor* executor, Program* program, FrameStack* frameStack
                 int index = high << 8 | low;
 
                 MethodRef* method = classFile->constantPool->pool[index-1]->constant->methodRef;
-                NameAndTypeIndex* nameAndType = classFile->constantPool->pool[method->nameAndTypeIndex-1]->constant->nameAndTypeIndex;
-                UTF8* nameUtf = classFile->constantPool->pool[nameAndType->nameIndex-1]->constant->utf8;
+                NameAndType* nameAndType = method->nameAndType;
+                UTF8* nameUtf = nameAndType->name;
 
                 char* nameString = utf82cstring(nameUtf);
 
@@ -433,8 +433,7 @@ void executeProgram(Executor* executor, Program* program, FrameStack* frameStack
                 int index = high << 8 | low;
 
                 MethodRef* method = classFile->constantPool->pool[index-1]->constant->methodRef;
-                NameAndTypeIndex* nameAndType = classFile->constantPool->pool[method->nameAndTypeIndex-1]->constant->nameAndTypeIndex;
-                UTF8* nameUtf = classFile->constantPool->pool[nameAndType->nameIndex-1]->constant->utf8;
+                UTF8* nameUtf = method->nameAndType->name;
 
                 char* nameString = utf82cstring(nameUtf);
 
@@ -455,12 +454,10 @@ void executeProgram(Executor* executor, Program* program, FrameStack* frameStack
 
                 // MethodRef and FieldRef are identical
                 MethodRef* field = classFile->constantPool->pool[i-1]->constant->methodRef;
-                NameAndTypeIndex* nameAndType = classFile->constantPool->pool[field->nameAndTypeIndex-1]->constant->nameAndTypeIndex;
-                UTF8* nameUtf = classFile->constantPool->pool[nameAndType->nameIndex-1]->constant->utf8;
-                UTF8* typeUtf = classFile->constantPool->pool[nameAndType->descriptorIndex-1]->constant->utf8;
+                UTF8* nameUtf = field->nameAndType->name;
+                UTF8* typeUtf = field->nameAndType->descriptor;
 
-                Class* containingClass = classFile->constantPool->pool[field->classIndex-1]->constant->class;
-                UTF8* containingClassName = classFile->constantPool->pool[containingClass->nameIndex-1]->constant->utf8;
+                UTF8* containingClassName = field->class->name;
                 char* containingClassNameString = utf82cstring(containingClassName);
                 ClassFile* containingClassFile = getClassFileAndExecuteIfNew(executor, frameStack, containingClassNameString);
 
@@ -481,12 +478,10 @@ void executeProgram(Executor* executor, Program* program, FrameStack* frameStack
 
                 // MethodRef and FieldRef are identical
                 MethodRef* field = classFile->constantPool->pool[i-1]->constant->methodRef;
-                NameAndTypeIndex* nameAndType = classFile->constantPool->pool[field->nameAndTypeIndex-1]->constant->nameAndTypeIndex;
-                UTF8* nameUtf = classFile->constantPool->pool[nameAndType->nameIndex-1]->constant->utf8;
-                UTF8* typeUtf = classFile->constantPool->pool[nameAndType->descriptorIndex-1]->constant->utf8;
+                UTF8* nameUtf = field->nameAndType->name;
+                UTF8* typeUtf = field->nameAndType->descriptor;
 
-                Class* containingClass = classFile->constantPool->pool[field->classIndex-1]->constant->class;
-                UTF8* containingClassName = classFile->constantPool->pool[containingClass->nameIndex-1]->constant->utf8;
+                UTF8* containingClassName = field->class->name;
                 char* containingClassNameString = utf82cstring(containingClassName);
                 ClassFile* containingClassFile = getClassFileAndExecuteIfNew(executor, frameStack, containingClassNameString);
 
@@ -504,13 +499,10 @@ void executeProgram(Executor* executor, Program* program, FrameStack* frameStack
                 int index = high << 8 | low;
                 ConstantPoolInfo* constant = classFile->constantPool->pool[index-1];
                 MethodRef* method = constant->constant->methodRef;
-                NameAndTypeIndex* nameAndTypeIndex = classFile->constantPool->pool[method->nameAndTypeIndex-1]->constant->nameAndTypeIndex;
-                uint16_t methodNameIndex = nameAndTypeIndex->nameIndex;
-                UTF8* methodName = classFile->constantPool->pool[methodNameIndex-1]->constant->utf8;
-                uint16_t otherClassIndex = classFile->constantPool->pool[method->classIndex - 1]->constant->class->nameIndex;
-                UTF8* otherClassName = classFile->constantPool->pool[otherClassIndex - 1]->constant->utf8;
+                UTF8* methodName = method->nameAndType->name;
+                UTF8* otherClassName = method->class->name;
                 char* otherClassString = utf82cstring(otherClassName);
-                UTF8* descriptor = classFile->constantPool->pool[nameAndTypeIndex->descriptorIndex-1]->constant->utf8;
+                UTF8* descriptor = method->nameAndType->descriptor;
 
                 ClassFile* otherClass = getClassFile(executor->loader, otherClassString, NULL);
 
@@ -595,12 +587,9 @@ void executeProgram(Executor* executor, Program* program, FrameStack* frameStack
                 int index = high << 8 | low;
                 MethodRef* methodRef = classFile->constantPool->pool[index-1]->constant->methodRef;
                 //Add getting the ClassFile index later.
-                NameAndTypeIndex* nameAndTypeIndex = classFile->constantPool->pool[methodRef->nameAndTypeIndex-1]->constant->nameAndTypeIndex;
-                uint16_t methodNameIndex = nameAndTypeIndex->nameIndex;
-                UTF8* methodName = classFile->constantPool->pool[methodNameIndex-1]->constant->utf8;
-                UTF8* descriptor = classFile->constantPool->pool[nameAndTypeIndex->descriptorIndex-1]->constant->utf8;
-                Class* otherClass = classFile->constantPool->pool[methodRef->classIndex-1]->constant->class;
-                UTF8* otherClassUtf8 = classFile->constantPool->pool[otherClass->nameIndex-1]->constant->utf8;
+                UTF8* methodName = methodRef->nameAndType->name;
+                UTF8* descriptor = methodRef->nameAndType->descriptor;
+                UTF8* otherClassUtf8 = methodRef->class->name;
                 char* otherClassString = utf82cstring(otherClassUtf8);
                 ClassFile* otherClassFile = getClassFileAndExecuteIfNew(executor, frameStack, otherClassString);
                 free(otherClassString);
@@ -612,16 +601,12 @@ void executeProgram(Executor* executor, Program* program, FrameStack* frameStack
                 int8_t low = *((int8_t*)(++pc));
                 int index = high << 8 | low;
                 MethodRef* methodRef = classFile->constantPool->pool[index-1]->constant->methodRef;
-
-                NameAndTypeIndex* nameAndType = classFile->constantPool->pool[methodRef->nameAndTypeIndex-1]->constant->nameAndTypeIndex;
-                uint16_t methodNameIndex = nameAndType->nameIndex;
-                UTF8* methodName = classFile->constantPool->pool[methodNameIndex-1]->constant->utf8;
-
-                UTF8* descriptor = classFile->constantPool->pool[nameAndType->descriptorIndex-1]->constant->utf8;
+                UTF8* methodName = methodRef->nameAndType->name;
+                UTF8* descriptor = methodRef->nameAndType->descriptor;
 
                 // TODO(Landry): Test how inherited methods work here
-                Class* class = classFile->constantPool->pool[methodRef->classIndex-1]->constant->class;
-                UTF8* className = classFile->constantPool->pool[class->nameIndex-1]->constant->utf8;
+                Class* class = methodRef->class;
+                UTF8* className = class->name;
 
                 if (class->classFile == NULL) {
                     class->classFile = getClassFileAndExecuteIfNew(executor, frameStack, utf82cstring(className));

--- a/javarunner/src/execution_engine/executor.c
+++ b/javarunner/src/execution_engine/executor.c
@@ -79,8 +79,8 @@ MethodInfo* lookupMethodInDirectClass(const ClassFile* instanceClass, UTF8* name
     for (int i = 0; i < instanceClass->methodPool->size; i++) {
         MethodInfo* info = instanceClass->methodPool->pool[i];
 
-        UTF8* methodName = instanceClass->constantPool->pool[info->nameIndex-1]->constant->utf8;
-        UTF8* methodDescriptor = instanceClass->constantPool->pool[info->descriptorIndex-1]->constant->utf8;
+        UTF8* methodName = info->name;
+        UTF8* methodDescriptor = info->descriptor;
 
         if (isEqualUtf8(methodName, name) && isEqualUtf8(methodDescriptor, descriptor)) {
             return info;
@@ -127,8 +127,8 @@ int execute(Executor* executor, MethodInfo* method, const ClassFile* classFile, 
     if(code == NULL) {
         if (isNative(method)) {
             // execute native
-            UTF8* methodName = classFile->constantPool->pool[method->nameIndex-1]->constant->utf8;
-            UTF8* descriptor = classFile->constantPool->pool[method->descriptorIndex-1]->constant->utf8;
+            UTF8* methodName = method->name;
+            UTF8* descriptor = method->descriptor;
             executeNativeMethod(classFile, method->argumentCount, methodName, descriptor, frameStack, isVirtual);
             return 0;
         }
@@ -169,10 +169,7 @@ int executeByName(Executor* executor, const ClassFile *classFile, char* methodNa
     MethodPool* methodPool = classFile->methodPool;
     for(int i = 0; i < methodPool->size; i++) {
         MethodInfo* info = methodPool->pool[i];
-        UTF8* methodNameUtf8 = classFile->constantPool->pool[info->nameIndex-1]->constant->utf8;
-        char* currentMethodName = utf82cstring(methodNameUtf8);
-
-        if(strcmp(currentMethodName, methodName) == 0) {
+        if(isEqual(info->name, methodName)) {
             return execute(executor, info, classFile, frameStack, isVirtual);
         }
     }


### PR DESCRIPTION
Converts error-prone and verbose searches of constant pool to cache the constants. This makes it easier to find values.